### PR TITLE
Update to run under Sakai 10.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,10 @@
 	<description>A simplified entity provider for the Signup tool</description>
 
 	<parent>
-		<groupId>org.sakaiproject.purepoms</groupId>
-		<artifactId>sakai-standard-tool</artifactId>
-		<version>2.8.4</version>
+		<groupId>org.sakaiproject</groupId>
+		<artifactId>master</artifactId>
+		<version>10-SNAPSHOT</version>
+		<relativePath>../master/pom.xml</relativePath>
 	</parent>
 
 	<inceptionYear>2011</inceptionYear>
@@ -67,18 +68,6 @@
 				<enabled>true</enabled>
 			</snapshots>
 		</repository>
-		<repository>
-			<id>oxford-snapshots</id>
-			<name>Oxford Maven repo</name>
-			<layout>default</layout>
-			<url>http://maven-repo.oucs.ox.ac.uk/content/repositories/snapshots/</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
 	</repositories>
 
 	<dependencies>
@@ -93,75 +82,57 @@
 		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>
 			<artifactId>sakai-kernel-api</artifactId>
-			<version>1.2.5ox1-SNAPSHOT</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>
 			<artifactId>sakai-kernel-util</artifactId>
-			<version>1.2.5ox1-SNAPSHOT</version>
-			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.sakaiproject.kernel</groupId>
 			<artifactId>sakai-component-manager</artifactId>
-			<version>1.2.5ox1-SNAPSHOT</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.sakaiproject.entitybroker</groupId>
 			<artifactId>entitybroker-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.sakaiproject</groupId>
+			<groupId>org.sakaiproject.calendar</groupId>
 			<artifactId>sakai-calendar-api</artifactId>
-			<version>2.8.1</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.sakaiproject.entitybroker</groupId>
 			<artifactId>entitybroker-utils</artifactId>
-			<version>1.4.3</version>
-			<scope>compile</scope>
 		</dependency>
 
 		<!--  Signup dependencies -->
 		<dependency>
 			<groupId>org.sakaiproject.signup</groupId>
 			<artifactId>signup-api</artifactId>
-			<version>1.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		
 		<!--  External dependencies -->
 		<dependency>
 			<groupId>org.springframework</groupId>
-			<artifactId>spring</artifactId>
-			<version>2.5.6.SEC02</version>
+			<artifactId>spring-beans</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
-			<version>2.5</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
-			<version>1.1.1</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>servlet-api</artifactId>
-			<version>2.4</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>0.10.8</version>
+			<version>1.16.4</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
The build was compiling against Sakai 2.8 although we are running against Sakai 10, I’ve updated the dependencies to run against Sakai 10 so that we can be sure we won’t get runtime errors. This also fixes the problems with having old kernel classes in IDEs.
